### PR TITLE
Fix usage of the tool in "-mod=vendor" mode for projects with indirect dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 vendor
+.vscode
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ go:
   - 1.9.x
   - 1.10.x
   - 1.11.x
+  - 1.12.x
+  - 1.13.x
   - tip
 
 matrix:
@@ -17,11 +19,11 @@ os:
   - osx
 
 install:
-  - go mod download || go get -u
+  - env GO111MODULE=on go mod download || go get -u
 
 before_script:
-  - if [[ "$(go version)" =~ "go version go1.8" ]]; then echo Skipping golangci-lint; else make lint-prepare; fi
+  - if [[ "$TRAVIS_GO_VERSION" =~ ^1\.8 ]]; then echo 'Skipping golangci-lint install'; else make lint-prepare; fi
 
 script:
-  - if [[ "$(go version)" =~ "go version go1.8" ]]; then echo Skipping golangci-lint; else make lint; fi
-  - make test
+  - if [[ "$TRAVIS_GO_VERSION" =~ ^1\.8 ]]; then echo 'Skipping golangci-lint run'; else env GO111MODULE=on make lint; fi
+  - env GO111MODULE=on make test

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-[![Build Status](https://travis-ci.org/uudashr/gopkgs.svg?branch=master)](https://travis-ci.org/uudashr/gopkgs)
-[![GoDoc](https://godoc.org/github.com/uudashr/gopkgs?status.svg)](https://godoc.org/github.com/uudashr/gopkgs)
+[![Build Status](https://travis-ci.org/uudashr/gopkgs.svg?branch=master)](https://travis-ci.org/uudashr/gopkgs)[![GoDoc](https://godoc.org/github.com/uudashr/gopkgs?status.svg)](https://godoc.org/github.com/uudashr/gopkgs)
+
 # gopkgs
 
-Gopkgs is tools that provide list of available Go packages that can be imported.
+`gopkgs` is a tool that provides list of available Go packages that can be imported.
 
 This is an alternative to `go list all`, just faster.
 
@@ -10,8 +10,13 @@ This is an alternative to `go list all`, just faster.
 
 `$ go get -u github.com/uudashr/gopkgs/cmd/gopkgs`
 
+or, using **Go 1.12+**:
+
+`$ go get github.com/uudashr/gopkgs/cmd/gopkgs@latest`
+
 ## Usage
-```
+
+```plaintext
 $ gopkgs -help
   -format string
     	custom output format (default "{{.ImportPath}}")
@@ -34,8 +39,10 @@ Use -workDir={path} to speed up the package search. This will ignore any vendor 
 ```
 
 ### Example
+
 Get package name along with the import path.
-```
+
+```plaintext
 $ gopkgs -format "{{.Name}};{{.ImportPath}}"
 testing;github.com/mattes/migrate/source/testing
 http;github.com/stretchr/testify/http
@@ -58,4 +65,4 @@ Use `-workDir={path}` flag, it will speed up the package search by ignoring the 
 
 ## Related Project
 
-This is based on https://github.com/haya14busa/gopkgs but taking slightly different path by simplifying its implementation.
+This is based on <https://github.com/haya14busa/gopkgs> but takes slightly different path by simplifying its implementation.

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/uudashr/gopkgs
 go 1.12
 
 require (
-	github.com/karrick/godirwalk v1.11.3
+	github.com/karrick/godirwalk v1.12.0
 	github.com/pkg/errors v0.8.1
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/uudashr/gopkgs
 
+go 1.12
+
 require (
-	github.com/karrick/godirwalk v1.7.1
-	github.com/pkg/errors v0.8.0
+	github.com/karrick/godirwalk v1.11.3
+	github.com/pkg/errors v0.8.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/karrick/godirwalk v1.11.3 h1:ZrtYOzzHRzItdU1MvkK3CLlhC4m3YTWFgGyiBuSCQSY=
-github.com/karrick/godirwalk v1.11.3/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaRPx4tDPEn4=
+github.com/karrick/godirwalk v1.12.0 h1:nkS4xxsjiZMvVlazd0mFyiwD4BR9f3m6LXGhM2TUx3Y=
+github.com/karrick/godirwalk v1.12.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaRPx4tDPEn4=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/karrick/godirwalk v1.7.1 h1:r3iVkkQFDuU9wELXmnGx0oRcizvC744QszlA4OxqwFE=
-github.com/karrick/godirwalk v1.7.1/go.mod h1:svlOlzFUryGta1ycTmmd6C6ytFMtCkPvQ/4fj4EXtU4=
-github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
-github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/karrick/godirwalk v1.11.3 h1:ZrtYOzzHRzItdU1MvkK3CLlhC4m3YTWFgGyiBuSCQSY=
+github.com/karrick/godirwalk v1.11.3/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaRPx4tDPEn4=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/gopkgs.go
+++ b/gopkgs.go
@@ -15,6 +15,12 @@ import (
 	pkgerrors "github.com/pkg/errors"
 )
 
+const (
+	mainPkg        = "main"
+	testDataDir    = "testdata"
+	nodeModulesDir = "node_modules"
+)
+
 // Pkg hold the information of the package.
 type Pkg struct {
 	Dir        string // directory containing package sources
@@ -126,7 +132,7 @@ func listFiles(srcDir, workDir string, noVendor bool) (<-chan goFile, <-chan err
 				// see: https://golang.org/cmd/go/#hdr-Description_of_package_lists
 
 				if de.IsDir() {
-					if name[0] == '.' || name[0] == '_' || name == "testdata" || name == "node_modules" {
+					if name[0] == '.' || name[0] == '_' || name == testDataDir || name == nodeModulesDir {
 						return filepath.SkipDir
 					}
 
@@ -205,7 +211,7 @@ func listModFiles(modDir string) (<-chan goFile, <-chan error) {
 				// see: https://golang.org/cmd/go/#hdr-Description_of_package_lists
 
 				if de.IsDir() {
-					if name[0] == '.' || name[0] == '_' || name == "testdata" || name == "node_modules" {
+					if name[0] == '.' || name[0] == '_' || name == testDataDir || name == nodeModulesDir {
 						return filepath.SkipDir
 					}
 
@@ -255,7 +261,7 @@ func collectPkgs(srcDir, workDir string, noVendor bool, out map[string]Pkg) erro
 			continue
 		}
 
-		if pkgName == "main" {
+		if pkgName == mainPkg {
 			// skip main package
 			continue
 		}
@@ -289,7 +295,7 @@ func collectModPkgs(m mod, out map[string]Pkg) error {
 			continue
 		}
 
-		if pkgName == "main" {
+		if pkgName == mainPkg {
 			// skip main package
 			continue
 		}
@@ -363,7 +369,7 @@ type mod struct {
 }
 
 func listMods(workDir string) ([]mod, error) {
-	cmdArgs := []string{"list", "-m", "-f={{.Path}};{{.Dir}}", "all"}
+	cmdArgs := []string{"list", "-m", `-mod=""`, "-f={{.Path}};{{.Dir}}", "all"}
 	cmd := exec.Command("go", cmdArgs...)
 	cmd.Dir = workDir
 	out, err := cmd.Output()


### PR DESCRIPTION
This is a rework of the PR #16
We ignore the flag `-mod=vendor` by strictly using the `-mod=` flag.