### PR TITLE
Fix `go get` by using `v2`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,7 @@ os:
   - osx
 
 before_install:
-  - if [[ "$TRAVIS_GO_VERSION" =~ ^1\.8 ]] || [[ "$TRAVIS_GO_VERSION" =~ ^1\.9 ]] || [[ "$TRAVIS_GO_VERSION" =~ ^1\.10 ]]; then \
-    cd .. && mkdir v2 && mv gopkgs/* v2/ &&  mv v2 gopkgs/v2; fi
+  - if [[ "$TRAVIS_GO_VERSION" =~ ^1\.8 ]] || [[ "$TRAVIS_GO_VERSION" =~ ^1\.9 ]] || [[ "$TRAVIS_GO_VERSION" =~ ^1\.10 ]]; then cd .. && mkdir v2 && mv gopkgs/* v2/ &&  mv v2 gopkgs/v2; fi
 
 install:
   - env GO111MODULE=on go mod download || go get -u

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,10 @@ os:
   - linux
   - osx
 
+before_install:
+  - if [[ "$TRAVIS_GO_VERSION" =~ ^1\.8 ]] || [[ "$TRAVIS_GO_VERSION" =~ ^1\.9 ]] || [[ "$TRAVIS_GO_VERSION" =~ ^1\.10 ]]; then \
+    cd .. && mkdir v2 && mv gopkgs/* v2/ &&  mv v2 gopkgs/v2; fi
+
 install:
   - env GO111MODULE=on go mod download || go get -u
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ os:
   - osx
 
 before_install:
-  - if [[ "$TRAVIS_GO_VERSION" =~ ^1\.8 ]] || [[ "$TRAVIS_GO_VERSION" =~ ^1\.9 ]] || [[ "$TRAVIS_GO_VERSION" =~ ^1\.10 ]]; then cd .. && mkdir v2 && mv gopkgs/* v2/ &&  mv v2 gopkgs/v2; fi
+  - if [[ "$TRAVIS_GO_VERSION" =~ ^1\.8 ]] || [[ "$TRAVIS_GO_VERSION" =~ ^1\.9 ]] || [[ "$TRAVIS_GO_VERSION" =~ ^1\.10 ]]; then cd .. && mkdir v2 && mv gopkgs/* v2/ && mv v2 gopkgs/v2 && cd gopkgs/v2; fi
 
 install:
   - env GO111MODULE=on go mod download || go get -u

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is an alternative to `go list all`, just faster.
 
 or, using **Go 1.12+**:
 
-`$ go get github.com/uudashr/gopkgs/cmd/gopkgs@latest`
+`$ go get github.com/uudashr/gopkgs/v2/cmd/gopkgs@latest`
 
 ## Usage
 
@@ -61,7 +61,7 @@ awss3;github.com/mattes/migrate/source/aws-s3
 
 ### Tips
 
-Use `-workDir={path}` flag, it will speed up the package search by ignoring the exernal vendor.
+Use `-workDir={path}` flag, it will speed up the package search by ignoring the external vendor.
 
 ## Related Project
 

--- a/cmd/gopkgs/main.go
+++ b/cmd/gopkgs/main.go
@@ -10,7 +10,7 @@ import (
 	"runtime/trace"
 	"text/tabwriter"
 
-	"github.com/uudashr/gopkgs"
+	"github.com/uudashr/gopkgs/v2"
 )
 
 var usageInfo = `

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/uudashr/gopkgs
+module github.com/uudashr/gopkgs/v2
 
 go 1.12
 

--- a/gopkgs.go
+++ b/gopkgs.go
@@ -384,9 +384,6 @@ func listMods(workDir string) ([]mod, error) {
 	for s.Scan() {
 		line := s.Text()
 		ls := strings.Split(line, ";")
-		if err != nil {
-			return nil, err
-		}
 		mods = append(mods, mod{path: ls[0], dir: ls[1]})
 	}
 	return mods, nil

--- a/gopkgs.go
+++ b/gopkgs.go
@@ -3,7 +3,6 @@ package gopkgs
 import (
 	"bufio"
 	"bytes"
-	"errors"
 	"go/build"
 	"io"
 	"os"
@@ -12,10 +11,14 @@ import (
 	"strings"
 
 	"github.com/karrick/godirwalk"
-	pkgerrors "github.com/pkg/errors"
+	"github.com/pkg/errors"
 )
 
 const (
+	goFlagsEnv    = "GOFLAGS"
+	modEmptyFlag  = "-mod="
+	modVendorFlag = "-mod=vendor"
+
 	mainPkg        = "main"
 	testDataDir    = "testdata"
 	nodeModulesDir = "node_modules"
@@ -75,7 +78,7 @@ func readPackageName(filename string) (string, error) {
 				ls := strings.Split(line, " ")
 				if len(ls) < 2 {
 					mustClose(f)
-					return "", errors.New("expect pattern 'package <name>':" + line)
+					return "", errors.Errorf("expect pattern 'package <name>':%s", line)
 				}
 
 				mustClose(f)
@@ -169,7 +172,7 @@ func listFiles(srcDir, workDir string, noVendor bool) (<-chan goFile, <-chan err
 				return nil
 			},
 			ErrorCallback: func(s string, err error) godirwalk.ErrorAction {
-				err = pkgerrors.Cause(err)
+				err = errors.Cause(err)
 				if v, ok := err.(*os.PathError); ok && (os.IsNotExist(v.Err) || os.IsPermission(v.Err)) {
 					return godirwalk.SkipNode
 				}
@@ -229,7 +232,7 @@ func listModFiles(modDir string) (<-chan goFile, <-chan error) {
 				return nil
 			},
 			ErrorCallback: func(s string, err error) godirwalk.ErrorAction {
-				err = pkgerrors.Cause(err)
+				err = errors.Cause(err)
 				if v, ok := err.(*os.PathError); ok && os.IsNotExist(v.Err) {
 					return godirwalk.SkipNode
 				}
@@ -280,8 +283,17 @@ func collectPkgs(srcDir, workDir string, noVendor bool, out map[string]Pkg) erro
 	return nil
 }
 
-func collectModPkgs(m mod, out map[string]Pkg) error {
-	filec, errc := listModFiles(m.dir)
+func collectModPkgs(m mod, vendorMode bool, out map[string]Pkg) error {
+	// choose proper directory for search
+	dir := m.pkgDir
+	if vendorMode {
+		var err error
+		if dir, err = pickDir(m.pkgDir, m.vendorDir); err != nil {
+			return errors.Wrap(err, "unable to list mod files")
+		}
+	}
+
+	filec, errc := listModFiles(dir)
 	for f := range filec {
 		pkgDir := f.dir
 		if _, found := out[pkgDir]; found {
@@ -302,8 +314,13 @@ func collectModPkgs(m mod, out map[string]Pkg) error {
 
 		// debug := true
 		importPath := m.path
-		if pkgDir != m.dir {
-			importPath += filepath.ToSlash(pkgDir[len(m.dir):])
+		if pkgDir != dir {
+			// remove prefix if pkg is vendored
+			if vendorMode && strings.HasPrefix(pkgDir, dir+"/vendor") {
+				importPath = strings.TrimPrefix(pkgDir, dir+"/vendor/")
+			} else {
+				importPath += filepath.ToSlash(pkgDir[len(dir):])
+			}
 		}
 
 		out[pkgDir] = Pkg{
@@ -336,7 +353,8 @@ func List(opts Options) (map[string]Pkg, error) {
 		return pkgs, nil
 	}
 
-	mods, err := listMods(opts.WorkDir)
+	vendorMode := checkVendorMode()
+	mods, err := listMods(opts.WorkDir, vendorMode)
 	if err != nil {
 		// GOPATH mode
 		for _, srcDir := range build.Default.SrcDirs() {
@@ -354,7 +372,7 @@ func List(opts Options) (map[string]Pkg, error) {
 	}
 
 	for _, m := range mods {
-		err = collectModPkgs(m, pkgs)
+		err = collectModPkgs(m, vendorMode, pkgs)
 		if err != nil {
 			return nil, err
 		}
@@ -364,12 +382,54 @@ func List(opts Options) (map[string]Pkg, error) {
 }
 
 type mod struct {
-	path string
-	dir  string
+	path      string
+	pkgDir    string
+	vendorDir string
 }
 
-func listMods(workDir string) ([]mod, error) {
-	cmdArgs := []string{"list", "-m", `-mod=""`, "-f={{.Path}};{{.Dir}}", "all"}
+func listMods(workDir string, vendorMode bool) ([]mod, error) {
+	// exec `go list -m ...` to get module path list
+	// if GOFLAGS contains '-mod=vendor', it gets vendor path list instead
+	s, err := execGoList(workDir, "list", "-m", "-f={{.Path}};{{.Dir}}", "all")
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to execute `go list -m ...`")
+	}
+
+	var mods []mod
+	for s.Scan() {
+		line := s.Text()
+		ls := strings.Split(line, ";")
+		if vendorMode {
+			mods = append(mods, mod{path: ls[0], vendorDir: ls[1]})
+		} else {
+			mods = append(mods, mod{path: ls[0], pkgDir: ls[1]})
+		}
+	}
+
+	// if GOFLAGS contains '-mod=vendor', exec `go list -mod= -m ...` to fill the module paths as well
+	if vendorMode {
+		s, err = execGoList(workDir, "list", modEmptyFlag, "-m", "-f={{.Path}};{{.Dir}}", "all")
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to execute `go list -mod= -m ...`")
+		}
+
+		keyIndexMap := make(map[string]int, len(mods))
+		for i, m := range mods {
+			keyIndexMap[m.path] = i
+		}
+		for s.Scan() {
+			line := s.Text()
+			ls := strings.Split(line, ";")
+			if _, ok := keyIndexMap[ls[0]]; ok {
+				mods[keyIndexMap[ls[0]]].pkgDir = ls[1]
+			}
+		}
+	}
+
+	return mods, nil
+}
+
+func execGoList(workDir string, cmdArgs ...string) (*bufio.Scanner, error) {
 	cmd := exec.Command("go", cmdArgs...)
 	cmd.Dir = workDir
 	out, err := cmd.Output()
@@ -377,12 +437,20 @@ func listMods(workDir string) ([]mod, error) {
 		return nil, err
 	}
 
-	var mods []mod
-	s := bufio.NewScanner(bytes.NewReader(out))
-	for s.Scan() {
-		line := s.Text()
-		ls := strings.Split(line, ";")
-		mods = append(mods, mod{path: ls[0], dir: ls[1]})
+	return bufio.NewScanner(bytes.NewReader(out)), nil
+}
+
+func checkVendorMode() bool {
+	return strings.Contains(os.Getenv(goFlagsEnv), modVendorFlag)
+}
+
+// we prefer vendorDir to pkgDir if it exists
+func pickDir(pkgDir, vendorDir string) (string, error) {
+	if _, err := os.Stat(vendorDir); !os.IsNotExist(err) {
+		return vendorDir, nil
 	}
-	return mods, nil
+	if _, err := os.Stat(pkgDir); !os.IsNotExist(err) {
+		return pkgDir, nil
+	}
+	return "", os.ErrNotExist
 }

--- a/gopkgs_test.go
+++ b/gopkgs_test.go
@@ -1,7 +1,10 @@
 package gopkgs_test
 
-import "testing"
-import "github.com/uudashr/gopkgs"
+import (
+	"testing"
+
+	"github.com/uudashr/gopkgs/v2"
+)
 
 func TestList(t *testing.T) {
 	if testing.Short() {


### PR DESCRIPTION
~~Re-implemented the `-mod=vendor` fix (see #16) and~~
Fixed `go get` by using `v2` in module path and a few linter and build issues.
