### PR TITLE
Add new `v2` module and make `cmd/gopkgs` use it 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,9 @@ TRAVIS_GO_VERSION ?= $(GO_VERSION_MINOR).x
 GOLANGCI_LINT_1.9.x := v1.10.2
 GOLANGCI_LINT_1.10.x := v1.15.0
 GOLANGCI_LINT_1.11.x := v1.17.1
-GOLANGCI_LINT_1.12.x := v1.19.1
-GOLANGCI_LINT_1.13.x := v1.19.1
-GOLANGCI_LINT_tip := v1.19.1
+GOLANGCI_LINT_1.12.x := v1.21.0
+GOLANGCI_LINT_1.13.x := v1.21.0
+GOLANGCI_LINT_tip := v1.21.0
 GOLANGCI_LINT := ${GOLANGCI_LINT_${TRAVIS_GO_VERSION}}
 
 # Linter
@@ -18,7 +18,7 @@ GOLANGCI_LINT := ${GOLANGCI_LINT_${TRAVIS_GO_VERSION}}
 lint-prepare:
 	@if [ $(GOLANGCI_LINT) == "" ]; then \
 		echo "Unknown Go version - using the latest linter"; \
-		GOLANGCI_LINT := v1.19.1; \
+		GOLANGCI_LINT := $(GOLANGCI_LINT_tip); \
 	fi
 	@echo "Installing golangci-lint $(GOLANGCI_LINT)"
 	@[ -d $(GOPATH)/bin ] || mkdir -p $(GOPATH)/bin

--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@ This is an alternative to `go list all`, just faster.
 
 or, using **Go 1.12+**:
 
-`$ go get github.com/uudashr/gopkgs/v2/cmd/gopkgs@latest`
+`$ go get github.com/uudashr/gopkgs/cmd/gopkgs@latest`
 
 ## Usage
+
+### Tool
 
 ```plaintext
 $ gopkgs -help
@@ -39,6 +41,14 @@ Use -format to custom the output using template syntax. The struct being passed 
 
 Use -workDir={path} to speed up the package search. This will ignore any vendor package outside the package root.
 ```
+
+### Library
+
+This project adheres to the Go modules [release strategy](https://github.com/golang/go/wiki/Modules#releasing-modules-v2-or-higher) by using the `Major subdirectory` approach.
+
+Starting from version `v2.0.3`, you're able to use either `github.com/uudashr/gopkgs` or `github.com/uudashr/gopkgs/v2` versions independently.
+
+The tool `cmd/gopkgs` uses `v2` package internally.
 
 ### Example
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is an alternative to `go list all`, just faster.
 
 or, using **Go 1.12+**:
 
-`$ go get github.com/uudashr/gopkgs/cmd/gopkgs@latest`
+`$ go get github.com/uudashr/gopkgs/v2/cmd/gopkgs@latest`
 
 ## Usage
 

--- a/cmd/gopkgs/go.mod
+++ b/cmd/gopkgs/go.mod
@@ -1,0 +1,10 @@
+module github.com/uudashr/gopkgs/cmd/gopkgs
+
+go 1.13
+
+require github.com/uudashr/gopkgs/v2 v2.0.3
+
+replace (
+	github.com/uudashr/gopkgs => ../../
+	github.com/uudashr/gopkgs/v2 => ../../v2
+)

--- a/cmd/gopkgs/go.sum
+++ b/cmd/gopkgs/go.sum
@@ -1,0 +1,4 @@
+github.com/karrick/godirwalk v1.12.0 h1:nkS4xxsjiZMvVlazd0mFyiwD4BR9f3m6LXGhM2TUx3Y=
+github.com/karrick/godirwalk v1.12.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaRPx4tDPEn4=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/cmd/gopkgs/main.go
+++ b/cmd/gopkgs/main.go
@@ -10,7 +10,7 @@ import (
 	"runtime/trace"
 	"text/tabwriter"
 
-	"github.com/uudashr/gopkgs"
+	gopkgs "github.com/uudashr/gopkgs/v2"
 )
 
 var usageInfo = `

--- a/gopkgs.go
+++ b/gopkgs.go
@@ -384,9 +384,6 @@ func listMods(workDir string) ([]mod, error) {
 	for s.Scan() {
 		line := s.Text()
 		ls := strings.Split(line, ";")
-		if err != nil {
-			return nil, err
-		}
 		mods = append(mods, mod{path: ls[0], dir: ls[1]})
 	}
 	return mods, nil

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -1,0 +1,7 @@
+module github.com/uudashr/gopkgs/v2
+
+go 1.13
+
+require github.com/uudashr/gopkgs v0.0.0
+
+replace github.com/uudashr/gopkgs => ../

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -1,0 +1,4 @@
+github.com/karrick/godirwalk v1.12.0 h1:nkS4xxsjiZMvVlazd0mFyiwD4BR9f3m6LXGhM2TUx3Y=
+github.com/karrick/godirwalk v1.12.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaRPx4tDPEn4=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/v2/gopkgs.go
+++ b/v2/gopkgs.go
@@ -1,0 +1,25 @@
+package gopkgs
+
+import (
+	v1 "github.com/uudashr/gopkgs"
+)
+
+// Pkg hold the information of the package.
+type Pkg v1.Pkg
+
+// Options for retrieve packages.
+type Options v1.Options
+
+// List packages on workDir.
+func List(opts Options) (map[string]Pkg, error) {
+	result, err := v1.List(v1.Options(opts))
+	if err != nil {
+		return nil, err
+	}
+
+	pkgs := make(map[string]Pkg, len(result))
+	for key, pkg := range result {
+		pkgs[key] = Pkg(pkg)
+	}
+	return pkgs, nil
+}

--- a/v2/gopkgs_test.go
+++ b/v2/gopkgs_test.go
@@ -3,7 +3,7 @@ package gopkgs_test
 import (
 	"testing"
 
-	"github.com/uudashr/gopkgs"
+	gopkgs "github.com/uudashr/gopkgs/v2"
 )
 
 func TestList(t *testing.T) {


### PR DESCRIPTION
Continuing the work discussed in the #20.

As per the `Major subdirectory` approach suggested by the [Go module wiki](https://github.com/golang/go/wiki/Modules#releasing-modules-v2-or-higher), this PR makes the project adhere to `v2` release policy of the Go modules.
New `v2` folder reuses the code from the main module, `cmd/gopkgs` is also a module now which can use either of the main module versions.

This change also allows us to:
- independently update the app or/and the library
- make both new `v1.x` and `v2.x` releases
- reuse the same code without duplication (although that may change in the future)
- allow both non-module users and module users use the same code

Also updated the linter to `v1.21.0`.