### PR TITLE
vulnerability fix: sanitize filename

### DIFF
--- a/internal/gopkgs.go
+++ b/internal/gopkgs.go
@@ -48,6 +48,7 @@ func mustClose(c io.Closer) {
 }
 
 func readPackageName(filename string) (string, error) {
+	// #nosec G304 - no prefix based access checks performed, false positive
 	f, err := os.Open(filename)
 	if err != nil {
 		return "", err

--- a/v2/internal/gopkgs.go
+++ b/v2/internal/gopkgs.go
@@ -48,6 +48,7 @@ func mustClose(c io.Closer) {
 }
 
 func readPackageName(filename string) (string, error) {
+	// #nosec G304 - no prefix based access checks performed, false positive
 	f, err := os.Open(filename)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Hi Nuruddin! I'm Ivan and I work at [Bison Trails](https://bisontrails.co/). We're doing an internal hackathon this week.

Our team loves gopkgs, but it got flagged during a recent security review. Our team voted to use our hackathon time to patch vulnerabilities in our favorite OSS tools and specifically to try to get gopkgs approved for usage within our organization. 

## What's here:
- filename parameter of readPackageName function is sanitized
## Impact: 
These changes should improve gopkgs's security posture. We identified these vulnerabilities using [Salus](https://github.com/coinbase/salus) and the [OSSF scorecard](https://github.com/ossf/scorecard). The specific issues I am hoping to address here are:
- gosec [G304](https://securego.io/docs/rules/g304.html) vulnerability can allow attacker to access parts of the directory tree which otherwise would be disallowed. And while as of now no prefix based checks are performed on the filename, they might be added in future. And this change will safeguard against potential problems

Thank you so much for your work maintaining gopkgs, and thank you for taking the time to look at these proposed changes!